### PR TITLE
Set default ACL value to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.50 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.62.0 |
 
 ## Modules
 
@@ -40,7 +40,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_acl"></a> [acl](#input\_acl) | Private or Public ACL | `string` | `"private"` | no |
+| <a name="input_acl"></a> [acl](#input\_acl) | Private or Public ACL | `string` | `null` | no |
 | <a name="input_acm_key_algorithm"></a> [acm\_key\_algorithm](#input\_acm\_key\_algorithm) | ACM certificate algorithm | `string` | `"EC_prime256v1"` | no |
 | <a name="input_attach_policy"></a> [attach\_policy](#input\_attach\_policy) | Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy) | `bool` | `true` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "bucket_name" {
 variable "acl" {
   description = "Private or Public ACL"
   type        = string
-  default     = "private"
+  default     = null
 }
 
 variable "attach_policy" {


### PR DESCRIPTION
Purpose of this PR is to fix the below issue. S3 buckets would have ACls disabled by default (https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/).

**Error creating S3 bucket ACL for $BUCKET: AccessControlListNotSupported: The bucket does not allow ACLs**

terraform-aws-modules/s3-bucket/aws has also set **acl** default as null.