### PR TITLE
fix: region issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | <a name="input_region"></a> [region](#input\_region) | Region where the resources will be managed. Default to region set in the provider configuration | `string` | `null` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `true` | no |
 | <a name="input_s3_origin_access_control_key"></a> [s3\_origin\_access\_control\_key](#input\_s3\_origin\_access\_control\_key) | Key in `origin_access_control` to use for S3 origin access control | `string` | `"s3"` | no |
+| <a name="input_s3_region"></a> [s3\_region](#input\_s3\_region) | Region to manage the s3 bucket in. Default to region set in the provider configuration | `string` | `null` | no |
 | <a name="input_server_side_encryption_configuration"></a> [server\_side\_encryption\_configuration](#input\_server\_side\_encryption\_configuration) | Map containing server-side encryption configuration. | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be associated with the cloudfront distribution | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | Map containing versioning configuration. | `map(string)` | <pre>{<br/>  "enabled": true<br/>}</pre> | no |

--- a/acm.tf
+++ b/acm.tf
@@ -8,7 +8,7 @@ module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 6.0.0"
 
-  region = var.region
+  region = "us-east-1"
 
   create_certificate     = var.create_certificate
   create_route53_records = false

--- a/example/main.tf
+++ b/example/main.tf
@@ -7,6 +7,8 @@ module "s3_test_static" {
   bucket_name = "static-site-testing-tfmodule"
   policy      = data.aws_iam_policy_document.s3_policy_additional.json
 
+  s3_region = "ap-southeast-1"
+
   domains = {
     default_domain = {
       dns_zone_id         = ""

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "region" {
   default     = null
 }
 
+variable "s3_region" {
+  description = "Region to manage the s3 bucket in. Default to region set in the provider configuration"
+  type        = string
+  default     = null
+}
+
 variable "acl" {
   description = "Private or Public ACL"
   type        = string


### PR DESCRIPTION
Fixes https://github.com/SPHTech-Platform/terraform-aws-s3-cloudfront-static-site/pull/33

Issue stem from the AWS provider v6 support update
- region attribute should only be setting for s3 resource
- cloudfront and ACM cert will only deploy to us-east-1